### PR TITLE
feat: 🎸 added Table visualizataion for NEOs

### DIFF
--- a/src/components/BarChart.tsx
+++ b/src/components/BarChart.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
-import { BarChartData, BarChartOptions } from '../types/BarChart';
+import { ChartData, BarChartOptions } from '../types/Chart';
 
 type Props = {
-    data: BarChartData;
+    data: ChartData;
     options: BarChartOptions;
 };
 
@@ -26,7 +26,7 @@ const BarChart: React.FC<Props> = ({ data, options }) => {
     return <ChartDiv id="bar-chart" />
 };
 
-const drawChart = (data: any, options: any) => {
+const drawChart = (data: ChartData, options: BarChartOptions) => {
     const formattedData = google.visualization.arrayToDataTable(data);
     const chart = new google.visualization.BarChart(document.getElementById('bar-chart'));
     chart.draw(formattedData, options);

--- a/src/components/TableChart.tsx
+++ b/src/components/TableChart.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { ChartData, TableChartOptions } from '../types/Chart';
+
+type Props = {
+    data: ChartData;
+    options: TableChartOptions;
+};
+
+const TableChart: React.FC<Props> = ({ data, options }) => {
+    const [isReadyToDraw, setIsReadyToDraw] = useState(false);
+
+    useEffect(() => {
+        google.charts.load('current', {'packages':['table']});
+        google.charts.setOnLoadCallback(() => setIsReadyToDraw(true));
+    }, []);
+
+    useEffect(() => {
+        if (!isReadyToDraw) {
+            return;
+        }
+        drawChart(data, options);
+    }, [data, options, isReadyToDraw]);
+
+    return <ChartDiv id="table-chart" />
+};
+
+const drawChart = (data: ChartData, options: TableChartOptions) => {
+    const formattedData = new google.visualization.DataTable();
+    formattedData.addColumn('string', data[0][0]);
+    formattedData.addColumn('number', data[0][1]);
+    formattedData.addColumn('number', data[0][2]);
+    formattedData.addRows(data.slice(1));
+    const chart = new google.visualization.Table(document.getElementById('table-chart'));
+    chart.draw(formattedData, options);
+};
+
+const ChartDiv = styled.div`
+    height: 80%;
+`;
+
+export default TableChart;

--- a/src/containers/NearEarthObjects/index.tsx
+++ b/src/containers/NearEarthObjects/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import Select from 'react-select';
 import NearEarthObject from '../../types/NearEarthObject';
 import { Option } from '../../types/Select';
 import API from './api';

--- a/src/pages/NEOChart.tsx
+++ b/src/pages/NEOChart.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Select from 'react-select';
 import BarChart from '../components/BarChart';
+import TableChart from '../components/TableChart';
 import NearEarthObjectsContainer from '../containers/NearEarthObjects';
-import { BarChartOptions } from '../types/BarChart';
+import { BarChartOptions, TableChartOptions } from '../types/Chart';
+import { Option } from '../types/Select';
 import { mapNearEarthObjectsToBarChartData } from './utils';
 
-const options: BarChartOptions = {
+const barOptions: BarChartOptions = {
     title: 'NEOs travelling around the Earth',
     hAxis: {
       title: 'Estimated Diameter (km)',
@@ -36,9 +38,23 @@ const options: BarChartOptions = {
     },
 };
 
+const tableOptions: TableChartOptions = {
+	showRowNumber: true,
+	width: '100%',
+	height: '100%',
+};
+
+const displayModes: Option[] = [
+	{ label: 'Bars', value: 'Bars' },
+	{ label: 'Table', value: 'Table' },
+];
+
 const NEOChart = () => {
-    return (
-        <>
+	const [displayMode, setDisplayMode] = useState<Option | null>(displayModes[0]);
+
+	return (
+		<>
+			<Select value={displayMode} onChange={setDisplayMode} options={displayModes} placeholder="Select display mode" />
 			<NearEarthObjectsContainer
 				renderFilter={({ filter, setFilter, filterOptions }) => (
 					<Select value={filter} options={filterOptions} onChange={setFilter} isClearable placeholder="Filter by orbiting" />
@@ -50,11 +66,14 @@ const NEOChart = () => {
 					if (error) {
 						return <p>Error: {error.message}</p>
 					}
-					return <BarChart data={mapNearEarthObjectsToBarChartData(nearEarthObjects)} options={options} />
-				}}
-			/>
+					const data = mapNearEarthObjectsToBarChartData(nearEarthObjects);
+					return (displayMode?.value === 'Bars')
+						? <BarChart data={data} options={barOptions} />
+						: <TableChart data={data} options={tableOptions} />
+			}}
+		/>
 		</>
-    );
+	);
 };
 
 export default NEOChart;

--- a/src/pages/utils.ts
+++ b/src/pages/utils.ts
@@ -1,9 +1,9 @@
-import { BarChartData } from '../types/BarChart';
+import { ChartData } from '../types/Chart';
 import NearEarthObject from '../types/NearEarthObject';
 
 export const getAverageDistance = (neo: NearEarthObject) => (neo.estimated_diameter.kilometers.estimated_diameter_min + neo.estimated_diameter.kilometers.estimated_diameter_max) / 2;
 
-export const mapNearEarthObjectsToBarChartData = (neos: NearEarthObject[]): BarChartData => [
+export const mapNearEarthObjectsToBarChartData = (neos: NearEarthObject[]): ChartData => [
     ['Neo Name', 'Min Estimated Diameter (km)', 'Max Estimated Diameter (km)'],
     ...neos
         .slice() // slice to create a shallow copy before performing a mutating operation: sort

--- a/src/types/Chart.d.ts
+++ b/src/types/Chart.d.ts
@@ -1,4 +1,4 @@
-export type BarChartData = Array<Array<string | number>>;
+export type ChartData = Array<Array<string | number>>;
 
 type TextStyleOptions = {
     bold: boolean;
@@ -21,4 +21,10 @@ export type BarChartOptions = {
     };
     hAxis: AxisOptions;
     vAxis: AxisOptions;
+};
+
+export type TableChartOptions = {
+    showRowNumber: boolean;
+    width: string;
+    height: string;
 };


### PR DESCRIPTION
Since I went for the render prop pattern in the container, this one was pretty easy: I just had to create a TableChart component that uses the same data as an input, write a different formatter and feed the Table from Google Charts.

I did not want to go as deep as creating a generic Chart component and feed it preformatted data the same way you do it at Botify ( https://medium.com/botify-labs/my-chart-will-go-on-4439101b5e2b ) because I was running out of time and wanted to try the CSV bonus step